### PR TITLE
PRINT-445 - Tracking URLs not correctly rendered for some UPS trackin…

### DIFF
--- a/tracking_url/__init__.py
+++ b/tracking_url/__init__.py
@@ -48,7 +48,12 @@ TRACKING_PATTERNS = [
         'UPS',
         'https://wwwapps.ups.com/WebTracking/track?track=yes&trackNums={tracking_number}',
         [
-            r'1Z[0-9A-Z]{16}|[\dT]\d{10}'
+            r'1Z[0-9A-Z]{16}|[\dT]\d{10}',
+            r'T\d{10}',
+            r'\d{9}',
+            r'\d{18}',
+            r'MI[\d]{6}[a-zA-Z0-9]{1,22}',
+            # r'\d{12}', # matches a fedex pattern; here for reference
         ]),
     TrackingPattern(
         'fedex',

--- a/tracking_url/tests/test_tracking_url.py
+++ b/tracking_url/tests/test_tracking_url.py
@@ -21,8 +21,12 @@ class GuessCarrierTestCase(TestCase):
             '1Z12345E0393657226',
             '1Z12345E1392654435',
             '1Z12345E6892410845',
-            '1Z12345E1591910450'
-        ])
+            '1Z12345E1591910450',
+        # Based on https://www.ups.com/ci/en/help-center/sri/tracking-number.page
+            'T1234567890',
+            '123456789',
+            '123456789012345678',
+        ] + [ 'MI123456' + 'A'*i for i in range(1, 23) ])
 
     def test_fedex(self):
         # from: https://stackoverflow.com/questions/11049025/how-can-i-get-fedex-testing-tracking-number


### PR DESCRIPTION
Added additional tracking number patterns for UPS based on [https://www.ups.com/ci/en/help-center/sri/tracking-number.page](What is a tracking number?) along with matching numbers to test.